### PR TITLE
Use database IDs to edit and delete Spectral Windows in Technical Goals

### DIFF
--- a/src/main/java/org/orph2020/pst/apiimpl/rest/ObservationResource.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/ObservationResource.java
@@ -235,7 +235,6 @@ public class ObservationResource extends ObjectResourceBase {
         TimingWindow window = findChildByQuery(Observation.class, TimingWindow.class,
                 "constraints", observationId, timingWindowId);
 
-        // only sets those members that are immediate children of the TimingWindow class
         window.updateUsing(replacementWindow);
 
         em.merge(window);


### PR DESCRIPTION
- use database IDs to refer to a specific ScienceSpectralWindow when updating or deleting existing entities in a TechnicalGoal
- remove obsolete comment in ObservationResource.java
- made some modifications to API calls for ExpectedSpectralLines in anticipation of future work