### PR TITLE
SupportingDocuments store to be removed on start-up 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,8 @@ dependencies {
     testImplementation("io.quarkus:quarkus-test-security")
 
     implementation("uk.ac.starlink:stil:4.1.4")
+
+    implementation("commons-io:commons-io:2.15.1")
 }
 
 

--- a/src/main/java/org/orph2020/pst/apiimpl/rest/SupportingDocumentResource.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/SupportingDocumentResource.java
@@ -1,5 +1,6 @@
 package org.orph2020.pst.apiimpl.rest;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -33,8 +34,9 @@ import java.util.List;
 @Produces(MediaType.APPLICATION_JSON)
 public class SupportingDocumentResource extends ObjectResourceBase {
 
-    //FIXME: need to confirm a path location on our server for this
-    private static final String documentStoreRoot = "/tmp/documentStore/";
+
+    @ConfigProperty(name= "supporting-documents.store-root")
+    String documentStoreRoot;
 
     private
     String sanitiseTitle(String input, ObservingProposal proposal)
@@ -257,7 +259,7 @@ public class SupportingDocumentResource extends ObjectResourceBase {
             throw new WebApplicationException("Cannot find " + fileDownload.getName(), 400);
         }
 
-        Response.ResponseBuilder response = Response.ok((Object) fileDownload);
+        Response.ResponseBuilder response = Response.ok(fileDownload);
         response.header("Content-Disposition", "attachment;filename=" + fileDownload.getName());
 
         return response.build();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -39,6 +39,9 @@ quarkus.oidc.application-type=service
 keycloak.admin-username=admin
 keycloak.admin-password=admin
 
+#Supporting Documents store root location fixme: change to an actual location for prod
+supporting-documents.store-root=/tmp/documentStore/
+
 #k8 related
 #should be picked up from name
 quarkus.helm.name=pst-api-service


### PR DESCRIPTION
 -  if a database query returns an empty list of SupportingDocuments assume content of document store to be stale,
 -  add the store root location to application.properties and use the 'ConfigProperty' annotation to load the value 
 -  add Apache commons-io for FileUtils to gradle build file