### PR TITLE
Document store cloned from the original proposal on submission

### DIFF
--- a/src/main/java/org/orph2020/pst/apiimpl/rest/ProposalDocumentStore.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/ProposalDocumentStore.java
@@ -3,6 +3,7 @@ package org.orph2020.pst.apiimpl.rest;
 import jakarta.enterprise.context.RequestScoped;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.ivoa.dm.proposal.prop.SupportingDocument;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -11,10 +12,15 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ *  This is a convenience class bean to help with file I/O and bookkeeping for the document store
+ *  of individual proposals
+ */
 @RequestScoped
 public class ProposalDocumentStore {
 
@@ -61,14 +67,22 @@ public class ProposalDocumentStore {
     }
 
     /**
-     * Copies the contents of directory 'source' to the directory 'destination', this includes
-     * subdirectories and files
-     * @param source a string representing the source directory
-     * @param destination a string representing the destination directory
+     * Copies the contents of directory 'source' to the directory 'destination', this includes subdirectories
+     * and files (intention is that 'source' and 'destination' are unique identifiers for proposals)
+     * @param source a string representing the source directory or path (not including the store root)
+     * @param destination a string representing the destination directory or path (not including the store root)
+     * @param supportingDocuments list of supporting documents from the CLONED proposal to update
+     *                            their 'locations' to use the 'destination' path - can be empty
      * @throws IOException if copy operation fails
      */
-    public void copyStore(String source, String destination) throws IOException {
+    public void copyStore(String source, String destination, List<SupportingDocument> supportingDocuments)
+            throws IOException {
         FileUtils.copyDirectory(fetchFile(source), fetchFile(destination));
+        supportingDocuments.forEach(s ->
+            s.setLocation(s.getLocation().replace(
+                    "proposals/" + source,"proposals/" + destination
+            ))
+        );
     }
 
 

--- a/src/main/java/org/orph2020/pst/apiimpl/rest/ProposalResource.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/ProposalResource.java
@@ -207,18 +207,15 @@ public class ProposalResource extends ObjectResourceBase {
 
         //copy the document store for the new, cloned proposal
         try {
-            proposalDocumentStore.copyStore(prop.getId().toString(), clonedProp.getId().toString());
+            proposalDocumentStore.copyStore(
+                    prop.getId().toString(),
+                    clonedProp.getId().toString(),
+                    clonedProp.getSupportingDocuments()
+            );
         }
         catch (IOException e) {
             throw new WebApplicationException(e);
         }
-
-        //clonedProp now has SupportingDocuments with 'locations' indicating the original proposal,
-        //these need to be updated with the clone's id.
-        clonedProp.getSupportingDocuments().forEach(
-                s -> s.setLocation(s.getLocation().replace(
-                        "proposals/" + prop.getId(),"proposals/" + clonedProp.getId()))
-        );
 
         return clonedProp;
     }


### PR DESCRIPTION
When submitting a proposal to a cycle the API now copies the original proposal's document store to one uniquely identified by the new "submitted-proposal". In essence, this creates a snapshot of the documents in the store at the point when the proposal was submitted. 

Notice that in doing this I have also moved the code that updates the clone's (or submitted-proposal's) supporting documents 'location' members into the implementation of 'ProposalDocumentStore.copyStore()' method. 