### PR TITLE
59 allow tac chair to withdraw a previously allocated proposal

### DIFF
--- a/src/main/java/org/orph2020/pst/apiimpl/rest/AllocatedProposalResource.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/AllocatedProposalResource.java
@@ -47,7 +47,7 @@ public class AllocatedProposalResource extends ObjectResourceBase{
 
 
     @PUT
-    @Operation(summary = "upgrade a proposal under review to an allocated proposal")
+    @Operation(summary = "upgrade a submitted proposal to an allocated proposal")
     @Consumes(MediaType.TEXT_PLAIN)
     @Transactional(rollbackOn = {WebApplicationException.class})
     public ProposalSynopsis allocateProposalToCycle(@PathParam("cycleCode") Long cycleCode,
@@ -74,11 +74,13 @@ public class AllocatedProposalResource extends ObjectResourceBase{
         return new ProposalSynopsis(allocatedProposal.getSubmitted());
     }
 
+    //TODO: make this callable by a 'TAC Chair' user only
     @DELETE
-    @Operation(summary = "withdraw a previously allocated proposal from the cycle, (to implement: TAC chair only)")
+    @Path("{allocatedId}")
+    @Operation(summary = "withdraw a previously allocated proposal from the cycle")
     @Transactional(rollbackOn = {WebApplicationException.class})
     public Response withdrawAllocatedProposal(@PathParam("cycleCode") Long cycleCode,
-                                              Long allocatedId)
+                                              @PathParam("allocatedId") Long allocatedId)
     throws WebApplicationException {
 
         ProposalCycle cycle = findObject(ProposalCycle.class, cycleCode);

--- a/src/test/java/org/orph2020/pst/apiimpl/rest/UseCaseTacChairTest.java
+++ b/src/test/java/org/orph2020/pst/apiimpl/rest/UseCaseTacChairTest.java
@@ -211,7 +211,7 @@ public class UseCaseTacChairTest {
               .then()
               .statusCode(204);
 
-      //check the list of allocated proposals; should now be zero
+      //check the list of allocated proposals; should now one fewer than before
       given()
               .when()
               .get("proposalCycles/" + cycleId + "/allocatedProposals")

--- a/src/test/java/org/orph2020/pst/apiimpl/rest/UseCaseTacChairTest.java
+++ b/src/test/java/org/orph2020/pst/apiimpl/rest/UseCaseTacChairTest.java
@@ -13,9 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import jakarta.inject.Inject;
-
-import java.util.Calendar;
-import java.util.Date;
+import java.util.List;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
@@ -46,9 +44,7 @@ public class UseCaseTacChairTest {
                   "$.size()", greaterThanOrEqualTo(1)
             )
             .extract().jsonPath().getLong("[0].dbid");
-      raObjectMapper = new Jackson2Mapper(((type, charset) -> {
-         return mapper;
-      }));
+      raObjectMapper = new Jackson2Mapper(((type, charset) -> mapper));
 
       TAC tac =
             given()
@@ -87,7 +83,7 @@ public class UseCaseTacChairTest {
             .extract().jsonPath().getLong("[0].dbid");
 
       // the TAC member gets a proposal for review
-      SubmittedProposal revprop = given()
+      given()
             .when()
             .get("proposalCycles/" + cycleId + "/submittedProposals/" + revId)
             .then()
@@ -142,7 +138,7 @@ public class UseCaseTacChairTest {
 
       //Create a new AllocatedBlock
       //IMPL have chosen the first of everything here - in GUI each will be a list.
-      Integer gradeId = given()
+      int gradeId = given()
               .when()
               .get("proposalCycles/" + cycleId + "/grades")
               .then()
@@ -161,7 +157,7 @@ public class UseCaseTacChairTest {
 
 
 
-      Integer resourceTypeId = given()
+      int resourceTypeId = given()
               .when()
               .get("proposalCycles/" + cycleId + "/availableResources/types" )
               .then()
@@ -186,12 +182,19 @@ public class UseCaseTacChairTest {
             }
       );
 
-      Integer allocatedId = given()
+      int allocatedId = given()
               .when()
               .get("proposalCycles/" + cycleId + "/allocatedProposals")
               .then()
               .body("$.size()", greaterThan(0))
               .extract().jsonPath().getInt("[0].dbid");
+
+      int allocationsSize = given()
+              .when()
+              .get("proposalCycles/" + cycleId + "/allocatedProposals")
+              .then()
+              .body("$.size()", greaterThan(0))
+              .extract().as(List.class).size();
 
       given()
               .when()
@@ -200,6 +203,20 @@ public class UseCaseTacChairTest {
               .post("proposalCycles/" + cycleId + "/allocatedProposals/" + allocatedId + "/allocatedBlock")
               .then()
               .statusCode(200);
+
+      //test remove the allocated proposal
+      given()
+              .when()
+              .delete("proposalCycles/" + cycleId + "/allocatedProposals/" + allocatedId)
+              .then()
+              .statusCode(204);
+
+      //check the list of allocated proposals; should now be zero
+      given()
+              .when()
+              .get("proposalCycles/" + cycleId + "/allocatedProposals")
+              .then()
+              .body("$.size()", equalTo(allocationsSize - 1));
 
    }
 


### PR DESCRIPTION
Add a DELETE API call using the ProposalCycle id and AllocatedProposal id in the rest endpoint that removes the given allocated proposal from the given proposal cycle. 

Updated UseCaseTacChairTest to call this endpoint and delete (or "withdraw") a previously allocated proposal.

Note that this should be restricted to the TAC Chair user only, but we have yet to get "roles" for the application to work successfully. 