### PR TITLE
409 abs nights vs hours

### DIFF
--- a/src/main/java/org/orph2020/pst/apiimpl/rest/OpticalTelescopeResource.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/OpticalTelescopeResource.java
@@ -138,6 +138,21 @@ public class OpticalTelescopeResource extends ObjectResourceBase {
     }
 
     /**
+     * returns the list of telescopes and hours to nights relationship.
+     * @return the map of the available telescope names to hour to night value.
+     */
+    @GET
+    @Path("nightRelationships")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "get a list of the optical telescopes night to " +
+            "hour relationships.")
+    public Response getOpticalTelescopeNightRelationships() {
+        return responseWrapper(
+                xmlReader.getNightRelationship().keySet().stream().toList(),
+                201);
+    }
+
+    /**
      * return the list of names for the available telescopes.
      * @return the list of the available telescopes.
      */

--- a/src/main/java/org/orph2020/pst/apiimpl/rest/ProposalResource.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/ProposalResource.java
@@ -820,7 +820,13 @@ public class ProposalResource extends ObjectResourceBase {
         HashMap<String, Person> existingPeopleMap = new HashMap<>();
         for (ObjectIdentifier pid: peopleIds) {
             Person personToAdd = personResource.getPerson(pid.dbid);
-            existingPeopleMap.put(personToAdd.getOrcidId().toString(), personToAdd);
+            if (personToAdd.getOrcidId() == null) {
+                existingPeopleMap.put(
+                        personToAdd.getFullName(), personToAdd);
+            } else {
+                existingPeopleMap.put(
+                    personToAdd.getOrcidId().toString(), personToAdd);
+            }
         }
 
         //Compare people and organisations to what's in the database
@@ -839,11 +845,17 @@ public class ProposalResource extends ObjectResourceBase {
             }
 
             //If person does not exist, add them
-            if(!existingPeopleMap.containsKey(person.getOrcidId().toString())) {
+            String key = person.getFullName();
+            if (person.getOrcidId() != null) {
+                key = person.getOrcidId().toString();
+            }
+
+
+            if(!existingPeopleMap.containsKey(key)) {
                 logger.info("Adding person " + person.getFullName());
                 person.setXmlId("0");
                 i.setPerson(personResource.createPerson(person));
-                existingPeopleMap.put(person.getOrcidId().toString(), i.getPerson());
+                existingPeopleMap.put(key, i.getPerson());
             }
         }
 


### PR DESCRIPTION
this adds support to the telescope xmls to include a relationship between nights and hours. this means the xml reader has now extracted the value from the xml, so new schema changes, and then those values are handed over by a rest api for the gui.

on top of this, there are fixs for submission which were found during the testing. specifically, that when the backend is rebooted. there is no standing relationship for user ids. so when a proposal is imported. the investigators are basically all suspect. including the pi, which if not adjusted to the current importer, can result it being imported, but not to the active user. There is also issues with new users which don't have orcid ids which causing the import to fail, as well as issues with organisations with partial data.   This pr includes fixing the investigators to include the user as PI, and to filter out other investigators which dont exist in the current polaris setup.