### PR TITLE
Scientific and Technical justifications in one LaTex document

### DIFF
--- a/src/main/data/justificationsHeaderTemplate.tex
+++ b/src/main/data/justificationsHeaderTemplate.tex
@@ -1,0 +1,5 @@
+% requires \usepackage{fancyhdr} in main
+\pagestyle{fancy}
+\fancyhead{}
+\fancyhead[LO,LE]{\textbf{PROPOSAL-TITLE-HERE}}
+\fancyhead[RO,RE]{\textbf{CYCLE-ID-HERE}}

--- a/src/main/data/mainTemplate.tex
+++ b/src/main/data/mainTemplate.tex
@@ -11,8 +11,8 @@
 % functions, or could use their own. In either case, the image files that the figures refer to
 % must be uploaded by the user.
 
-% Users are expected to provide a bibliography file literally named "refs.bib", and use the normal
-% syntax for LaTex citations in their text i.e., "~\cite{namedReference}".
+% Users are expected to provide a bibliography file, which will be renamed "refs.lib", and use
+% the normal syntax for LaTex citations in their text i.e., "~\cite{namedReference}".
 %
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -23,7 +23,7 @@
 \usepackage{graphicx}
 \usepackage{subfig}
 
-\title{Replace this with the proposal title and the cycle number}
+\title{REPLACE_PROPOSAL_TITLE}
 %%%%% empty author and date wanted
 \author{}
 \date{}
@@ -78,18 +78,18 @@
 
     \section*{Scientific Justification}
 
-% Insert user's scientific justification text here
+%INSERT_SCIENTIFIC_TEXT%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
     \section*{Technical Justification}
 
-% Insert user's technical justification text here
+%INSERT_TECHNICAL_TEXT%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
     \bibliographystyle{plain}
-% Users are expected to provide a bibliography file literally named "refs.bib"
+% Users are expected to provide the bibliography file
     \bibliography{refs}
 
 \end{document}

--- a/src/main/data/mainTemplate.tex
+++ b/src/main/data/mainTemplate.tex
@@ -1,0 +1,95 @@
+% This is a LaTeX template for the science and technical justifications of an e-MERLIN proposal.
+% If you are an observatory administrator of Polaris please modify this template to suit the needs
+% of your observatory.
+% 
+% It is the developer's intention that Polaris users simply provide the text for both scientific
+% and technical justifications, decorated with minimal LaTex command calls to insert figures and
+% citations. We recommend that any tables are included as figures, but we don't impose that as a
+% restriction.
+%
+% To insert figures into their Justifications document users can use the provided, custom
+% functions, or could use their own. In either case, the image files that the figures refer to
+% must be uploaded by the user.
+
+% Users are expected to provide a bibliography file literally named "refs.bib", and use the normal
+% syntax for LaTex citations in their text i.e., "~\cite{namedReference}".
+%
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% 
+\documentclass[11pt,a4paper,twoside]{article}
+%
+\usepackage[top=1.5cm, left=2.0cm, right=2.0cm, bottom=1.5cm]{geometry}
+\usepackage{graphicx}
+\usepackage{subfig}
+
+\title{Replace this with the proposal title and the cycle number}
+%%%%% empty author and date wanted
+\author{}
+\date{}
+
+%%%%%%%% Custom "insert figure" commands %%%%%%
+\newcommand{\onefigure}[3][.5]{%
+    \begin{figure}[ht]
+    \centering
+    \includegraphics[width=#1\textwidth]{#2}
+    \caption{#3}
+    \label{fig:#2}
+    \end{figure}
+}
+
+\newcommand{\twofigures}[4][.5]{%
+    \begin{figure}[ht]
+    \centering
+    \subfloat[]{\includegraphics[width=#1\textwidth]{#2}}
+    \subfloat[]{\includegraphics[width=#1\textwidth]{#3}}
+    \caption{#4}
+    \label{fig:#2}
+    \end{figure}
+}
+
+\newcommand{\threefigures}[5][.33]{%
+    \begin{figure}[ht]
+    \centering
+    \subfloat{\includegraphics[width=#1\textwidth]{#2}}
+    \subfloat{\includegraphics[width=#1\textwidth]{#3}}
+    \subfloat{\includegraphics[width=#1\textwidth]{#4}}
+    \caption{#5}
+    \label{fig:#2}
+    \end{figure}
+}
+
+\newcommand{\fourfigures}[6][.5]{%
+    \begin{figure}[ht]
+    \centering
+    \subfloat[]{\includegraphics[width=#1\textwidth]{#2}}
+    \subfloat[]{\includegraphics[width=#1\textwidth]{#3}}\\
+    \subfloat[]{\includegraphics[width=#1\textwidth]{#4}}
+    \subfloat[]{\includegraphics[width=#1\textwidth]{#5}}
+    \caption{#6}
+    \label{fig:#2}
+    \end{figure}
+}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\begin{document}
+    \maketitle
+
+    \section*{Scientific Justification}
+
+% Insert user's scientific justification text here
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+    \section*{Technical Justification}
+
+% Insert user's technical justification text here
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+    \bibliographystyle{plain}
+% Users are expected to provide a bibliography file literally named "refs.bib"
+    \bibliography{refs}
+
+\end{document}

--- a/src/main/data/mainTemplate.tex
+++ b/src/main/data/mainTemplate.tex
@@ -19,14 +19,10 @@
 % 
 \documentclass[11pt,a4paper,twoside]{article}
 %
-\usepackage[top=1.5cm, left=2.0cm, right=2.0cm, bottom=1.5cm]{geometry}
+\usepackage[textwidth=16cm,textheight=25cm,headheight=14pt]{geometry}
 \usepackage{graphicx}
 \usepackage{subfig}
-
-\title{REPLACE_PROPOSAL_TITLE}
-%%%%% empty author and date wanted
-\author{}
-\date{}
+\usepackage{fancyhdr}
 
 %%%%%%%% Custom "insert figure" commands %%%%%%
 \newcommand{\onefigure}[3][.5]{%
@@ -74,7 +70,10 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \begin{document}
-    \maketitle
+    \pagestyle{fancy}
+    \fancyhead{}
+    \fancyhead[LO,LE]{\textbf{PROPOSAL-TITLE-HERE}}
+    \fancyhead[RO,RE]{\textbf{CYCLE-ID-HERE}}
 
     \section*{Scientific Justification}
 

--- a/src/main/data/mainTemplate.tex
+++ b/src/main/data/mainTemplate.tex
@@ -70,25 +70,18 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \begin{document}
-    \pagestyle{fancy}
-    \fancyhead{}
-    \fancyhead[LO,LE]{\textbf{PROPOSAL-TITLE-HERE}}
-    \fancyhead[RO,RE]{\textbf{CYCLE-ID-HERE}}
+% Header file created when a proposal is created
+    \input{justificationsHeader}
 
-    \section*{Scientific Justification}
-
-%INSERT_SCIENTIFIC_TEXT%
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-    \section*{Technical Justification}
-
-%INSERT_TECHNICAL_TEXT%
+% Justification files created when user saves the relevant text
+    \input{scientificJustification}
+    \input{technicalJustification}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
     \bibliographystyle{plain}
-% Users are expected to provide the bibliography file
+% Users are expected to provide the bibliography file.
+% It will be renamed to "refs.bib" in the backend.
     \bibliography{refs}
 
 \end{document}

--- a/src/main/java/org/orph2020/pst/apiimpl/rest/JustificationsResource.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/JustificationsResource.java
@@ -42,8 +42,9 @@ public class JustificationsResource extends ObjectResourceBase {
 
     //singular file names for LaTeX and RST justifications
     String texFileName = "main.tex";
-    String templateTex = "mainTemplate.tex";
-    String rstFileName = "main.rst";
+    String scientificTexFileName = "scientificJustification.tex";
+    String technicalTexFileName = "technicalJustification.tex";
+    //String templateTex = "mainTemplate.tex";
 
     @Inject
     ProposalDocumentStore proposalDocumentStore;
@@ -111,7 +112,7 @@ public class JustificationsResource extends ObjectResourceBase {
                 scientific.setFormat(technical.getFormat());
                 if (technical.getFormat() == TextFormats.LATEX) {
                     try {
-                        insertTextIntoMainTex(proposalCode, scientific.getText(), technical.getText());
+                        createTechnicalJustificationTex(proposalCode, technical.getText());
                     } catch (IOException e) {
                         throw new WebApplicationException(e);
                     }
@@ -124,7 +125,7 @@ public class JustificationsResource extends ObjectResourceBase {
                 technical.setFormat(scientific.getFormat());
                 if (scientific.getFormat() == TextFormats.LATEX) {
                     try {
-                        insertTextIntoMainTex(proposalCode, scientific.getText(), technical.getText());
+                        createScientificJustificationTex(proposalCode, scientific.getText());
                     } catch (IOException e) {
                         throw new WebApplicationException(e);
                     }
@@ -601,39 +602,31 @@ public class JustificationsResource extends ObjectResourceBase {
         return extension;
     }
 
-    private void insertTextIntoMainTex(
+
+    private void createScientificJustificationTex(
             Long proposalCode,
-            String scientificText,
+            String scientificText
+    )
+            throws IOException {
+
+        String completeText = "\\section*{Scientific Justification}\n\n" + scientificText;
+
+        proposalDocumentStore.writeStringToFile(completeText,
+                justificationsStorePath(proposalCode) + "/" + scientificTexFileName
+        );
+    }
+
+    private void createTechnicalJustificationTex(
+            Long proposalCode,
             String technicalText
     )
             throws IOException {
 
-        String proposalTitleTarget = "PROPOSAL-TITLE-HERE";
-        String scientificTarget = "%INSERT_SCIENTIFIC_TEXT%";
-        String technicalTarget = "%INSERT_TECHNICAL_TEXT%";
+        String completeText = "\\section*{Technical Justification}\n\n" + technicalText;
 
-        ObservingProposal proposal = findObject(ObservingProposal.class, proposalCode);
-        String proposalTitle = proposal.getTitle();
-
-        //reading from this file
-        File templateFile = proposalDocumentStore.fetchFile(
-                justificationsStorePath(proposalCode) + "/" + templateTex);
-
-        //writing to this file
-        File mainFile = proposalDocumentStore.fetchFile(
-                justificationsStorePath(proposalCode) + "/" + texFileName);
-
-        String templateText = new String(Files.readAllBytes(templateFile.toPath()));
-
-        templateText = templateText.replace(proposalTitleTarget, proposalTitle);
-
-        templateText = templateText.replace(scientificTarget, scientificText);
-
-        String mainText = templateText.replace(technicalTarget, technicalText);
-
-        Files.write(mainFile.toPath(), mainText.getBytes());
+        proposalDocumentStore.writeStringToFile(completeText,
+                justificationsStorePath(proposalCode) + "/" + technicalTexFileName
+        );
     }
-
-
 }
 

--- a/src/main/java/org/orph2020/pst/apiimpl/rest/JustificationsResource.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/JustificationsResource.java
@@ -82,7 +82,7 @@ public class JustificationsResource extends ObjectResourceBase {
     @Consumes(MediaType.APPLICATION_JSON)
     @Transactional(rollbackOn={WebApplicationException.class})
     public Justification updateJustification(
-            @PathParam("proposalCode") long proposalCode,
+            @PathParam("proposalCode") Long proposalCode,
             @PathParam("which") String which,
             Justification incoming )
             throws WebApplicationException
@@ -111,7 +111,7 @@ public class JustificationsResource extends ObjectResourceBase {
     @Consumes(MediaType.APPLICATION_JSON)
     @Transactional(rollbackOn={WebApplicationException.class})
     public Justification addJustification(
-            @PathParam("proposalCode") long proposalCode,
+            @PathParam("proposalCode") Long proposalCode,
             @PathParam("which") String which,
             Justification incoming )
             throws WebApplicationException

--- a/src/main/java/org/orph2020/pst/apiimpl/rest/JustificationsResource.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/JustificationsResource.java
@@ -42,6 +42,7 @@ public class JustificationsResource extends ObjectResourceBase {
 
     //singular file names for LaTeX and RST justifications
     String texFileName = "main.tex";
+    String templateTex = "mainTemplate.tex";
     String rstFileName = "main.rst";
 
     @Inject
@@ -77,31 +78,74 @@ public class JustificationsResource extends ObjectResourceBase {
 
 
     @PUT
-    @Operation( summary = "update a technical or scientific Justification in the ObservingProposal specified by the 'proposalCode'")
-    @Path("{which}")
+    @Operation( summary = "update a scientific Justification in the ObservingProposal specified by the 'proposalCode'")
+    @Path("scientific")
     @Consumes(MediaType.APPLICATION_JSON)
     @Transactional(rollbackOn={WebApplicationException.class})
-    public Justification updateJustification(
+    public Justification updateScientificJustification(
             @PathParam("proposalCode") Long proposalCode,
-            @PathParam("which") String which,
+            Justification incoming)
+        throws WebApplicationException
+    {
+        Justification scientific = getWhichJustification(proposalCode, "scientific");
+        Justification technical = getWhichJustification(proposalCode, "technical");
+
+        if (scientific == null) {
+            throw new WebApplicationException(
+                    "The Proposal has no existing scientific justification, please 'add' one"
+            );
+        }
+
+        scientific.updateUsing(incoming);
+        em.merge(scientific);
+
+        //ensure the technical justification has the same format as the scientific justification
+        technical.setFormat(scientific.getFormat());
+
+        if (scientific.getFormat() == TextFormats.LATEX) {
+            try {
+                insertTextIntoMainTex(proposalCode, scientific.getText(), technical.getText());
+            } catch (IOException e) {
+                throw new WebApplicationException(e);
+            }
+        }
+
+        return scientific;
+    }
+
+
+    @PUT
+    @Operation( summary = "update a technical Justification in the ObservingProposal specified by the 'proposalCode'")
+    @Path("technical")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Transactional(rollbackOn={WebApplicationException.class})
+    public Justification updateTechnicalJustification(
+            @PathParam("proposalCode") Long proposalCode,
             Justification incoming )
             throws WebApplicationException
     {
-        Justification justification = getWhichJustification(proposalCode, which);
+        Justification scientific = getWhichJustification(proposalCode, "scientific");
+        Justification technical = getWhichJustification(proposalCode, "technical");
 
-        if (justification == null)
+        if (technical == null) {
             throw new WebApplicationException(
-                    String.format(
-                            "The Proposal has no existing %s justification, please 'add' one",
-                            which
-                    )
+                    "The Proposal has no existing technical justification, please 'add' one"
             );
+        }
 
-        justification.updateUsing(incoming);
+        technical.updateUsing(incoming);
+        em.merge(technical);
 
-        em.merge(justification);
+        //ensure the scientific justification has the same format as the technical justification
+        scientific.setFormat(technical.getFormat());
 
-        return justification;
+        try {
+            insertTextIntoMainTex(proposalCode, scientific.getText(), technical.getText());
+        } catch (IOException e) {
+            throw new WebApplicationException(e);
+        }
+
+        return technical;
     }
 
 
@@ -141,16 +185,18 @@ public class JustificationsResource extends ObjectResourceBase {
     //*********** LATEX and RST Justifications ************
 
     @GET
-    @Path("{which}/latexResource")
+    @Path("resourceFile")
     @Operation(summary = "list the resource files (images, bibliography) uploaded by the user")
     @Produces(MediaType.APPLICATION_JSON)
     public Set<String> getLatexResourceFiles(
-            @PathParam("proposalCode") Long proposalCode,
-            @PathParam("which") String which)
+            @PathParam("proposalCode") Long proposalCode)
         throws WebApplicationException
     {
+        //either justification will do to check the format as we ensure they are the same format
+        //elsewhere
+
         try {
-            Justification justification = getWhichJustification(proposalCode, which);
+            Justification justification = getWhichJustification(proposalCode, "scientific");
             List<String> extensions = new ArrayList<>();
             extensions.add(".jpg");
             extensions.add(".png");
@@ -159,7 +205,7 @@ public class JustificationsResource extends ObjectResourceBase {
             if (justification.getFormat() == TextFormats.LATEX) {
                 extensions.add(".bib");
             }
-            return proposalDocumentStore.listFilesIn(justificationsStorePath(proposalCode, which), extensions);
+            return proposalDocumentStore.listFilesIn(justificationsStorePath(proposalCode), extensions);
         } catch (IOException e) {
             throw new WebApplicationException(e.getMessage());
         }
@@ -171,96 +217,40 @@ public class JustificationsResource extends ObjectResourceBase {
 
     //non-transactional, no modification to the database occurs
     @POST
-    @Path("{which}/latexResource")
+    @Path("resourceFile")
     @Operation(summary = "add a resource file for LaTeX or RST Justifications; .bib, .jpg, .png, .eps supported only")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     public Response addLatexResourceFile(
             @PathParam("proposalCode") Long proposalCode,
-            @PathParam("which") String which,
             @RestForm("document") @Schema(implementation = UploadLatexResourceSchema.class)
             FileUpload fileUpload)
         throws WebApplicationException
     {
-        checkResourceUpload(fileUpload);
+        String extension = checkResourceUpload(fileUpload);
 
-        String filename = fileUpload.fileName();
+        String filename = extension.equals("bib") ? "refs.bib" : fileUpload.fileName();
 
         // save the uploaded file to the document store
         // this will overwrite existing files with the same filename
         if (!proposalDocumentStore.moveFile(fileUpload.uploadedFile().toFile(),
-                justificationsStorePath(proposalCode, which) + "/" + filename)) {
+                justificationsStorePath(proposalCode) + "/" + filename)) {
             throw new WebApplicationException("Unable to save uploaded file");
         }
 
         return Response.ok(String.format("File %s saved", filename)).build();
     }
 
-    @GET
-    @Path("{which}/mainFile")
-    @Operation(summary = "get the main file (.tex or .rst) of your justification")
-    @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    public Response getMainTextFile(
-            @PathParam("proposalCode") Long proposalCode,
-            @PathParam("which") String which
-    ) throws WebApplicationException
-    {
-        Justification justification = getWhichJustification(proposalCode, which);
-
-        String filename = justification.getFormat() == TextFormats.LATEX ? texFileName : rstFileName;
-
-        File fileDownload = proposalDocumentStore.fetchFile(
-                justificationsStorePath(proposalCode, which) + "/" + filename);
-
-        if (!fileDownload.exists()) {
-            throw new WebApplicationException(String.format("%s file not found", filename));
-        }
-
-        return Response.ok(fileDownload)
-                .header("Content-Disposition", "attachment; filename=" + fileDownload.getName())
-                .build();
-    }
-
-    @POST
-    @Path("{which}/mainFile")
-    @Operation(summary = "upload the main file (.tex or .rst) for your justification (overwrites any existing main file)")
-    @Consumes(MediaType.MULTIPART_FORM_DATA)
-    public Response addMainTextFile(
-            @PathParam("proposalCode") Long proposalCode,
-            @PathParam("which") String which,
-            @RestForm("document") @Schema(implementation = UploadLatexResourceSchema.class)
-            FileUpload fileUpload
-    )
-            throws WebApplicationException
-    {
-        checkMainFileUpload(fileUpload);
-
-        String extension = FilenameUtils.getExtension(fileUpload.fileName());
-
-        String filename = extension.equals("tex") ? texFileName : rstFileName;
-
-        // save the uploaded file to the document store,
-        // this will overwrite the existing file with the same filename
-        if (!proposalDocumentStore.moveFile(fileUpload.uploadedFile().toFile(),
-                justificationsStorePath(proposalCode, which) + "/" + filename)) {
-            throw new WebApplicationException("Unable to save uploaded file");
-        }
-
-        return Response.ok(String.format("File %s saved as %s", fileUpload.fileName(), filename)).build();
-    }
-
-
     //non-transactional, no modification to the database occurs
     @DELETE
-    @Path("{which}/latexResource")
+    @Path("resourceFile")
     @Operation(summary = "remove the given resource file from the Justification")
     @Consumes(MediaType.TEXT_PLAIN)
     public Response removeLatexResourceFile(
             @PathParam("proposalCode") Long proposalCode,
-            @PathParam("which") String which,
             String filename)
     throws WebApplicationException
     {
-        if (!proposalDocumentStore.deleteFile(justificationsStorePath(proposalCode, which) + "/" + filename)) {
+        if (!proposalDocumentStore.deleteFile(justificationsStorePath(proposalCode) + "/" + filename)) {
             throw new WebApplicationException(String.format("Unable to delete file: %s", filename));
         }
 
@@ -268,47 +258,25 @@ public class JustificationsResource extends ObjectResourceBase {
     }
 
     @GET
-    @Path ("{which}/checkForMain")
-    @Operation(summary = "checks for the existence of a 'main' file, either .tex or .rst")
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response checkForMainFile(@PathParam("proposalCode") Long proposalCode,
-                                     @PathParam("which") String which)
-        throws WebApplicationException
-    {
-        Justification justification = getWhichJustification(proposalCode, which);
-        String filename = justification.getFormat() == TextFormats.LATEX ? texFileName : rstFileName;
-
-
-        return responseWrapper(
-                proposalDocumentStore
-                        .fetchFile(justificationsStorePath(proposalCode, which) + "/" + filename)
-                        .exists(), 200
-        );
-    }
-
-    @GET
-    @Path ("{which}/checkForPdf")
+    @Path ("checkForPdf")
     @Operation(summary = "checks for the existence of a latex PDF output file")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response checkForPdf(@PathParam("proposalCode") Long proposalCode,
-                                @PathParam("which") String which
-    )
+    public Response checkForPdf(@PathParam("proposalCode") Long proposalCode)
         throws WebApplicationException
     {
         return responseWrapper(
                 proposalDocumentStore
-                        .fetchFile(justificationsStorePath(proposalCode, which) + "/out/" + which + "-justification.pdf")
+                        .fetchFile(justificationsStorePath(proposalCode) + "/out/" + "justification.pdf")
                         .exists(), 200
         );
     }
 
 
     @POST
-    @Path("{which}/latexPdf")
+    @Path("latexPdf")
     @Operation(summary = "create PDF of the LaTex Justification from supplied files, we recommend using 'warningsAsErrors=true'")
     @Produces(MediaType.APPLICATION_JSON)
     public Response createPDFLaTex(@PathParam("proposalCode") Long proposalCode,
-                                   @PathParam("which") String which,
                                    @RestQuery Boolean warningsAsErrors
     )
         throws WebApplicationException
@@ -322,19 +290,18 @@ public class JustificationsResource extends ObjectResourceBase {
         // attempt to speed up the next compilation. This has been observed to lead to potential
         // problems when producing the PDF output.
         // Removing the output directory on a failed run avoids this issue, but later runs will not
-        // benefit from a speed-up. As Justifications are, at most, intended to be a couple of A4
+        // benefit from a speed-up. As Justifications are intended to be only a handful of A4
         // pages in length, this is not a problem.
 
-        justificationIsLatex(proposalCode, which);
+        justificationIsLatex(proposalCode);
 
-        File mainTex = proposalDocumentStore.fetchFile(justificationsStorePath(proposalCode, which) + "/" + texFileName);
+        File mainTex = proposalDocumentStore.fetchFile(justificationsStorePath(proposalCode) + "/" + texFileName);
 
         if (!mainTex.exists()) {
             throw new WebApplicationException(String.format("%s file not found", texFileName));
         }
 
-        ProcessBuilder processBuilder = getLatexmkProcessBuilder(
-                mainTex.getAbsolutePath(), which);
+        ProcessBuilder processBuilder = getLatexmkProcessBuilder(mainTex.getAbsolutePath());
 
         try {
             Process process = processBuilder.start();
@@ -342,10 +309,10 @@ public class JustificationsResource extends ObjectResourceBase {
             int exitCode = process.waitFor();
 
             // output directory "out" created by latexmk process
-            File outputDir = proposalDocumentStore.fetchFile(justificationsStorePath(proposalCode, which) + "/out");
+            File outputDir = proposalDocumentStore.fetchFile(justificationsStorePath(proposalCode) + "/out");
 
             File logFile = proposalDocumentStore
-                    .fetchFile(justificationsStorePath(proposalCode, which) + "/out/" + which + "-justification.log");
+                    .fetchFile(justificationsStorePath(proposalCode) + "/out/" + "justification.log");
 
             List<String> warnings = findWarnings(Files.readString(logFile.toPath()));
 
@@ -384,7 +351,7 @@ public class JustificationsResource extends ObjectResourceBase {
 
         //fetch the output PDF of the Justification
         File output = proposalDocumentStore
-                .fetchFile(justificationsStorePath(proposalCode, which) + "/out/" + which + "-justification.pdf");
+                .fetchFile(justificationsStorePath(proposalCode) + "/out/" + "justification.pdf");
 
         return responseWrapper(
                 String.format("Latex compilation successful!\nPDF output file saved as: %s",
@@ -392,19 +359,17 @@ public class JustificationsResource extends ObjectResourceBase {
     }
 
     @GET
-    @Path("{which}/latexPdf/download")
+    @Path("latexPdf/download")
     @Operation(summary = "download the pdf file produced after successfully running 'latexmk'")
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    public Response downloadLatexPdf(
-            @PathParam("proposalCode") Long proposalCode,
-            @PathParam("which") String which)
+    public Response downloadLatexPdf(@PathParam("proposalCode") Long proposalCode)
         throws WebApplicationException {
 
-        justificationIsLatex(proposalCode, which);
+        justificationIsLatex(proposalCode);
 
         //fetch the output PDF of the Justification
         File output = proposalDocumentStore
-                .fetchFile(justificationsStorePath(proposalCode, which) + "/out/" + which + "-justification.pdf");
+                .fetchFile(justificationsStorePath(proposalCode) + "/out/" + "justification.pdf");
 
         if (!output.exists()) {
             throw new WebApplicationException(String.format("Nonexistent file: %s", output.getName()));
@@ -422,11 +387,10 @@ public class JustificationsResource extends ObjectResourceBase {
     /**
      * Create the path to the justifications section of the proposal document store
      * @param proposalCode proposal id
-     * @param which "scientific" or "technical"
      * @return string of the path to the justifications section
      */
-    private String justificationsStorePath(Long proposalCode, String which) {
-        return proposalCode + "/justifications/" + which;
+    private String justificationsStorePath(Long proposalCode) {
+        return proposalCode + "/justifications/";
     }
 
     /**
@@ -451,17 +415,16 @@ public class JustificationsResource extends ObjectResourceBase {
      * Convenience function to create the ProcessBuilder for 'latexmk'
      *
      * @param filePath  String containing the path-filename of the source *.tex file to compile
-     * @param which     String "type" of Justification
      * @return ProcessBuilder of the 'latexmk' command with desired options
      */
-    private ProcessBuilder getLatexmkProcessBuilder(String filePath, String which) {
+    private ProcessBuilder getLatexmkProcessBuilder(String filePath) {
         return new ProcessBuilder(
                 "latexmk",
                 "-cd", //change directory into the source subdirectory
                 "-pdf", //we want PDF output
                 "-interaction=nonstopmode", //i.e. non-interactive
                 "-output-directory=out", //relative to source directory due to '-cd' option
-                "-jobname=" + which + "-justification", //output base name
+                "-jobname=" + "justification", //output base name
                 filePath
         );
     }
@@ -516,25 +479,26 @@ public class JustificationsResource extends ObjectResourceBase {
      * Checks that the Justification exists and has Latex format
      *
      * @param proposalCode Long proposal id
-     * @param which        String "type" of Justification
      * @throws WebApplicationException if either the Justification does not exist or the format is not LATEX
      */
-    private void justificationIsLatex(Long proposalCode, String which)
+    private void justificationIsLatex(Long proposalCode)
             throws WebApplicationException
     {
-        Justification justification = getWhichJustification(proposalCode, which);
+        Justification scientific = getWhichJustification(proposalCode, "scientific");
+        Justification technical = getWhichJustification(proposalCode, "technical");
 
-        if (justification == null) {
+        //the following check should be impossible, but those are some famous last words.
+        if (scientific == null || technical == null) {
             throw new WebApplicationException(String.format(
-                    "Proposal code %d, %s justification does not exist",
-                    proposalCode, which
+                    "Proposal code %d, one or both of the justifications does not exist",
+                    proposalCode
             ));
         }
 
-        if (justification.getFormat() != TextFormats.LATEX) {
+        if (scientific.getFormat() != TextFormats.LATEX && technical.getFormat() != TextFormats.LATEX) {
             throw new WebApplicationException(String.format(
-                    "%s Justification not LaTeX format, current format: %s",
-                    which, justification.getFormat().toString()
+                    "Justifications not in LaTeX format, current formats scientific: %s, technical: %s",
+                    scientific.getFormat().toString(), technical.getFormat().toString()
             ));
         }
     }
@@ -542,10 +506,11 @@ public class JustificationsResource extends ObjectResourceBase {
     /**
      * Function to check uploaded files content-type and file extension
      * @param fileUpload the uploaded file
+     * @return String containing the file extension.
      * @throws WebApplicationException if fileUpload is null, or content-type is null,
      * or file extension is empty, or file extension does not match the content-type
      */
-    private void checkResourceUpload(FileUpload fileUpload)
+    private String checkResourceUpload(FileUpload fileUpload)
             throws WebApplicationException {
 
         if (fileUpload == null) {
@@ -589,38 +554,43 @@ public class JustificationsResource extends ObjectResourceBase {
         // actual contents of the file. However, on Linux and Linux-like systems uploaded files saved
         // in this way have read-write permissions for the 'user' only (the "application" is the user here),
         // i.e., no executable permissions, and no permissions for 'groups' or 'other users'.
+
+        return extension;
     }
 
-    private void checkMainFileUpload(FileUpload fileUpload) throws WebApplicationException {
-        if (fileUpload == null) {
-            throw new WebApplicationException("No file uploaded");
-        }
+    private void insertTextIntoMainTex(
+            Long proposalCode,
+            String scientificText,
+            String technicalText
+    )
+            throws IOException {
 
-        String contentType = fileUpload.contentType();
-        if (contentType == null) {
-            throw new WebApplicationException("No content type information available");
-        }
+        String proposalTitleTarget = "REPLACE_PROPOSAL_TITLE";
+        String scientificTarget = "%INSERT_SCIENTIFIC_TEXT%";
+        String technicalTarget = "%INSERT_TECHNICAL_TEXT%";
 
-        String extension = FilenameUtils.getExtension(fileUpload.fileName());
-        if (extension == null || extension.isEmpty()) {
-            throw new WebApplicationException("Uploads require the correct file extension");
-        }
+        ObservingProposal proposal = findObject(ObservingProposal.class, proposalCode);
+        String proposalTitle = proposal.getTitle();
 
-        // mime type for .rst unknown, so we use 'application/octet-stream' as a coverall.
-        switch (contentType) {
-            case "application/octet-stream":
-            case "application/x-tex":
-            case "text/x-tex":
-                if (!extension.equals("tex") && !extension.equals("rst"))
-                    throw new WebApplicationException(
-                            String.format("Invalid file extension: %s", extension));
-                break;
-            default:
-                throw new WebApplicationException(
-                        String.format("content-type: %s is not supported", contentType));
-        }
+        //reading from this file
+        File templateFile = proposalDocumentStore.fetchFile(
+                justificationsStorePath(proposalCode) + "/" + templateTex);
 
+        //writing to this file
+        File mainFile = proposalDocumentStore.fetchFile(
+                justificationsStorePath(proposalCode) + "/" + texFileName);
+
+        String templateText = new String(Files.readAllBytes(templateFile.toPath()));
+
+        templateText = templateText.replace(proposalTitleTarget, proposalTitle);
+
+        templateText = templateText.replace(scientificTarget, scientificText);
+
+        String mainText = templateText.replace(technicalTarget, technicalText);
+
+        Files.write(mainFile.toPath(), mainText.getBytes());
     }
+
 
 }
 

--- a/src/main/java/org/orph2020/pst/apiimpl/rest/JustificationsResource.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/JustificationsResource.java
@@ -150,7 +150,15 @@ public class JustificationsResource extends ObjectResourceBase {
         throws WebApplicationException
     {
         try {
-            String[] extensions = {".bib", ".jpg", "jpeg", ".png", ".eps"};
+            Justification justification = getWhichJustification(proposalCode, which);
+            List<String> extensions = new ArrayList<>();
+            extensions.add(".jpg");
+            extensions.add(".png");
+            extensions.add(".eps");
+            extensions.add(".jpeg");
+            if (justification.getFormat() == TextFormats.LATEX) {
+                extensions.add(".bib");
+            }
             return proposalDocumentStore.listFilesIn(justificationsStorePath(proposalCode, which), extensions);
         } catch (IOException e) {
             throw new WebApplicationException(e.getMessage());
@@ -275,7 +283,7 @@ public class JustificationsResource extends ObjectResourceBase {
     }
 
 
-    @GET
+    @POST
     @Path("{which}/latexPdf")
     @Operation(summary = "create PDF of the LaTex Justification from supplied files, we recommend using 'warningsAsErrors=true'")
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/org/orph2020/pst/apiimpl/rest/JustificationsResource.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/JustificationsResource.java
@@ -268,6 +268,25 @@ public class JustificationsResource extends ObjectResourceBase {
     }
 
     @GET
+    @Path ("{which}/checkForMain")
+    @Operation(summary = "checks for the existence of a 'main' file, either .tex or .rst")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response checkForMainFile(@PathParam("proposalCode") Long proposalCode,
+                                     @PathParam("which") String which)
+        throws WebApplicationException
+    {
+        Justification justification = getWhichJustification(proposalCode, which);
+        String filename = justification.getFormat() == TextFormats.LATEX ? texFileName : rstFileName;
+
+
+        return responseWrapper(
+                proposalDocumentStore
+                        .fetchFile(justificationsStorePath(proposalCode, which) + "/" + filename)
+                        .exists(), 200
+        );
+    }
+
+    @GET
     @Path ("{which}/checkForPdf")
     @Operation(summary = "checks for the existence of a latex PDF output file")
     @Produces(MediaType.APPLICATION_JSON)
@@ -279,7 +298,8 @@ public class JustificationsResource extends ObjectResourceBase {
         return responseWrapper(
                 proposalDocumentStore
                         .fetchFile(justificationsStorePath(proposalCode, which) + "/out/" + which + "-justification.pdf")
-                        .exists(), 200);
+                        .exists(), 200
+        );
     }
 
 

--- a/src/main/java/org/orph2020/pst/apiimpl/rest/ProposalDocumentStore.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/ProposalDocumentStore.java
@@ -43,31 +43,26 @@ public class ProposalDocumentStore {
         Files.createDirectories(Paths.get(
                 proposalStoreRoot,
                 proposalCode.toString(),
-                "justifications/scientific"
-        ));
-
-        Files.createDirectories(Paths.get(
-                proposalStoreRoot,
-                proposalCode.toString(),
-                "justifications/technical"
+                "justifications"
         ));
 
         //copy LaTex template for Justifications to the proposal store
         Files.copy(
                 Paths.get("src/main/data/mainTemplate.tex"),
-                Paths.get(proposalStoreRoot, proposalCode.toString(), "justifications/main.tex")
+                Paths.get(proposalStoreRoot, proposalCode.toString(),
+                        "justifications/mainTemplate.tex")
         );
     }
 
     /**
-     * Removes the subdirectory, including its subdirectories, specified.
+     * Removes the subdirectory specified, including its subdirectories.
      * We use this to clean up the document store when a proposal is deleted such that the
      * string parameter must refer to the top-level subdirectory for that proposal.
      * @param proposalDirectory the top-level subdirectory for the proposal being deleted
      * @throws IOException if deletion fails
      */
     public void removeStorePath(String proposalDirectory) throws IOException {
-        //this is a recursive delete
+        //this delete is recursive
         FileUtils.deleteDirectory(fetchFile(proposalDirectory));
     }
 
@@ -76,9 +71,9 @@ public class ProposalDocumentStore {
      * and files (intention is that 'source' and 'destination' are unique identifiers for proposals)
      * @param source a string representing the source directory or path (not including the store root)
      * @param destination a string representing the destination directory or path (not including the store root)
-     * @param supportingDocuments list of supporting documents from the CLONED proposal to update
+     * @param supportingDocuments the list of supporting documents from the CLONED proposal to update
      *                            their 'locations' to use the 'destination' path - can be empty
-     * @throws IOException if copy operation fails
+     * @throws IOException if the copy operation fails
      */
     public void copyStore(String source, String destination, List<SupportingDocument> supportingDocuments)
             throws IOException {
@@ -92,7 +87,7 @@ public class ProposalDocumentStore {
 
 
     /**
-     * Convenience method to fetch the file given from this DocumentStore, may refer to a directory
+     * Convenience method to fetch the file given from this DocumentStore may refer to a directory
      * (note: 'filePath' can refer to a non-existent file)
      * @param filePath filename of the file to fetch, can have optional parent paths
      * @return the file identified by the filepath in this DocumentStore
@@ -140,7 +135,7 @@ public class ProposalDocumentStore {
      * List files in the given directory, optionally provide a non-empty array of specific file
      * extension strings to look for
      * @param filePath where to look
-     * @param fileExtensions optional list of file extensions, can be left empty or null to list all files
+     * @param fileExtensions an optional list of file extensions can be left empty or null to list all files
      * @return Set of strings containing the files found
      * @throws IOException thrown by Files.list()
      */

--- a/src/main/java/org/orph2020/pst/apiimpl/rest/ProposalDocumentStore.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/ProposalDocumentStore.java
@@ -16,6 +16,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
 /**
  *  This is a convenience class bean to help with file I/O and bookkeeping for the document store
  *  of individual proposals
@@ -50,7 +52,8 @@ public class ProposalDocumentStore {
         Files.copy(
                 Paths.get("src/main/data/mainTemplate.tex"),
                 Paths.get(proposalStoreRoot, proposalCode.toString(),
-                        "justifications/mainTemplate.tex")
+                        "justifications/mainTemplate.tex"),
+                REPLACE_EXISTING
         );
     }
 

--- a/src/main/java/org/orph2020/pst/apiimpl/rest/ProposalDocumentStore.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/ProposalDocumentStore.java
@@ -51,6 +51,12 @@ public class ProposalDocumentStore {
                 proposalCode.toString(),
                 "justifications/technical"
         ));
+
+        //copy LaTex template for Justifications to the proposal store
+        Files.copy(
+                Paths.get("src/main/data/mainTemplate.tex"),
+                Paths.get(proposalStoreRoot, proposalCode.toString(), "justifications/main.tex")
+        );
     }
 
     /**

--- a/src/main/java/org/orph2020/pst/apiimpl/rest/ProposalDocumentStore.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/ProposalDocumentStore.java
@@ -48,11 +48,19 @@ public class ProposalDocumentStore {
                 "justifications"
         ));
 
-        //copy LaTex template for Justifications to the proposal store
+        //copy the LaTex main file for Justifications to the proposal store
         Files.copy(
                 Paths.get("src/main/data/mainTemplate.tex"),
                 Paths.get(proposalStoreRoot, proposalCode.toString(),
-                        "justifications/mainTemplate.tex"),
+                        "justifications/main.tex"),
+                REPLACE_EXISTING
+        );
+
+        //copy the LaTex header file template for Justifications to the proposal store
+        Files.copy(
+                Paths.get("src/main/data/justificationsHeaderTemplate.tex"),
+                Paths.get(proposalStoreRoot, proposalCode.toString(),
+                        "justifications/justificationsHeaderTemplate.tex"),
                 REPLACE_EXISTING
         );
     }
@@ -91,7 +99,7 @@ public class ProposalDocumentStore {
 
     /**
      * Convenience method to fetch the file given from this DocumentStore may refer to a directory
-     * (note: 'filePath' can refer to a non-existent file)
+     * (note: 'filePath' can refer to a non-existent file, it will be created)
      * @param filePath filename of the file to fetch, can have optional parent paths
      * @return the file identified by the filepath in this DocumentStore
      */
@@ -122,7 +130,7 @@ public class ProposalDocumentStore {
     }
 
     /**
-     * Write a given string to the given file
+     * Write a given string to the given file. This will overwrite any existing file.
      * @param theString the string you wish to write to file
      * @param filePath the path of the subdirectories to the file to which you will be writing
      * @throws IOException I/O exception from the writer object

--- a/src/main/java/org/orph2020/pst/apiimpl/rest/ProposalDocumentStore.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/ProposalDocumentStore.java
@@ -1,6 +1,5 @@
 package org.orph2020.pst.apiimpl.rest;
 
-import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.context.RequestScoped;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -12,7 +11,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -140,15 +138,15 @@ public class ProposalDocumentStore {
      * @return Set of strings containing the files found
      * @throws IOException thrown by Files.list()
      */
-    public Set<String> listFilesIn(String filePath, String[] fileExtensions) throws IOException {
+    public Set<String> listFilesIn(String filePath, List<String> fileExtensions) throws IOException {
         try (Stream<Path> stream = Files.list(Paths.get(proposalStoreRoot, filePath))) {
             return stream
                     .filter(file -> !Files.isDirectory(file))
                     .map(java.nio.file.Path::getFileName)
                     .map(java.nio.file.Path::toString)
                     .filter(f -> {
-                        if (fileExtensions != null && fileExtensions.length > 0) {
-                            return Arrays.stream(fileExtensions).anyMatch(f::endsWith);
+                        if (fileExtensions != null && !fileExtensions.isEmpty()) {
+                            return fileExtensions.stream().anyMatch(f::endsWith);
                         } else {
                             return true;
                         }

--- a/src/test/java/org/orph2020/pst/apiimpl/rest/UseCasePiTest.java
+++ b/src/test/java/org/orph2020/pst/apiimpl/rest/UseCasePiTest.java
@@ -219,21 +219,21 @@ public class UseCasePiTest {
         given()
                 .multiPart("document", earthImage)
                 .when()
-                .post("proposals/" + proposalid + "/justifications/scientific/latexResource")
+                .post("proposals/" + proposalid + "/justifications/resourceFile")
                 .then()
                 .body(containsString("File earth_profile.jpg saved"));
 
         given()
                 .multiPart("document", hhg2g_dp)
                 .when()
-                .post("proposals/" + proposalid + "/justifications/scientific/latexResource")
+                .post("proposals/" + proposalid + "/justifications/resourceFile")
                 .then()
                 .body(containsString("File hhg2g_dp.jpg saved"));
 
         given()
                 .multiPart("document", refs)
                 .when()
-                .post("proposals/" + proposalid + "/justifications/scientific/latexResource")
+                .post("proposals/" + proposalid + "/justifications/resourceFile")
                 .then()
                 .body(containsString("File refs.bib saved"));
 


### PR DESCRIPTION
After some deliberation, I've decided not to allow uploads of '.tex' (or '.rst') files. Instead...

Added a "mainTemplate.tex" file that is copied to the proposal's document store location for Justifications as "main.tex" on creation of the proposal. A file containing the details of the "header" for the Justification PDF, "justificationsHeaderTemplate.tex" is also copied to the same location as "main.tex". The placeholder proposal title is replaced at this point with the actual title. It is also replaced if the title is updated at a future time.

When a user saves either a scientific or technical justification text, a modular Tex file is created with an appropriate filename, which is inputted into the "main.tex" file (via the '\input' Latex command).

The "main.tex", along with any uploaded resource files (images, bibtex), is compiled on demand into a PDF.

The page count of the resultant PDF is sent in the response of the latex compilation API call. I've also added an explicit API call to retrieve the PDF page count should it be needed elsewhere. 

I am ignoring for the time-being any other format of Justification allowed by the data model (the GUI will do the same). These can be reintroduced at a future date. 