### PR TITLE
98 add endpoint to allow a user to change home institute

### DIFF
--- a/src/main/java/org/orph2020/pst/apiimpl/rest/ObjectResourceBase.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/ObjectResourceBase.java
@@ -124,6 +124,11 @@ abstract public class ObjectResourceBase {
         return Response.ok(writeAsJsonString(object)).status(statusCode).build();
     }
 
+    /**
+     * Indicates an operation was successful but with a no-content response. Generally used
+     * with DELETE operations but is not exclusive to them.
+     * @return empty response to indicate success but with no actual return value
+     */
     protected Response emptyResponse204() {
         return Response.noContent().build();
     }

--- a/src/main/java/org/orph2020/pst/apiimpl/rest/SubjectMapResource.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/SubjectMapResource.java
@@ -18,6 +18,7 @@ import org.jboss.resteasy.reactive.RestQuery;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
 import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.orph2020.pst.apiimpl.entities.SubjectMap;
 
@@ -35,7 +36,7 @@ public class SubjectMapResource extends ObjectResourceBase {
 
     Keycloak keycloak;
 
-    RealmResource realm;
+    RealmResource realmOrppst;
 
     @ConfigProperty(name = "keycloak.admin-username")
     String admin_username;
@@ -54,7 +55,7 @@ public class SubjectMapResource extends ObjectResourceBase {
                 .password(admin_password)
                 .build();
 
-        realm = keycloak.realm("orppst");
+        realmOrppst = keycloak.realm("orppst");
     }
 
     @PreDestroy
@@ -91,6 +92,7 @@ public class SubjectMapResource extends ObjectResourceBase {
       SubjectMap ob = new SubjectMap( user, uuid);
       return persistObject(ob);
     }
+
     @GET
     @Path("{id}")
     @Operation(summary = "get the SubjectMap specified by the 'id'")
@@ -107,23 +109,28 @@ public class SubjectMapResource extends ObjectResourceBase {
         }
     }
 
+    @GET
+    @Path("{personId}/uid")
+    @Operation(summary = "get the keycloak 'uid' related to the 'personId'")
+    public Response getSubjectMapUid(@PathParam("personId") Long personId)
+    {
+        SubjectMap subjectMap = findSubjectMap(personId);
 
+        return responseWrapper(subjectMap.uid,200);
+    }
 
     @GET
     @Path("keycloakUserUIDs")
     @Operation(summary = "get the unique IDs of existing keycloak realm users")
     public List<String> existingUserUIDs()
     {
-        List<UserRepresentation> userRepresentations = realm.users().list();
+        List<UserRepresentation> userRepresentations = realmOrppst.users().list();
 
         return userRepresentations
                 .stream()
                 .map(UserRepresentation::getId)
                 .collect(Collectors.toList());
     }
-
-
-
 
     @GET
     @Path("newUsers")
@@ -134,7 +141,7 @@ public class SubjectMapResource extends ObjectResourceBase {
     {
         AtomicReference<Integer> result = new AtomicReference<>(0);
 
-        List<UserRepresentation> userRepresentations = realm.users().list();
+        List<UserRepresentation> userRepresentations = realmOrppst.users().list();
 
         userRepresentations.forEach((ur) -> {
             TypedQuery<SubjectMap> q = em.createQuery(
@@ -169,5 +176,103 @@ public class SubjectMapResource extends ObjectResourceBase {
         return result.get();
     }
 
+    @PUT
+    @Path("{personId}/firstName")
+    @Operation(summary = "change the given person's first name")
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Transactional(rollbackOn = {WebApplicationException.class})
+    public Response changeFirstName(@PathParam("personId") Long personId, String firstName)
+            throws WebApplicationException
+    {
+        SubjectMap subjectMap = findSubjectMap(personId);
+
+        //this does not change the firstname in the Keycloak realm
+        realmOrppst.users().get(subjectMap.uid).toRepresentation(true).setFirstName(firstName);
+
+        Person person = findObject(Person.class, personId);
+
+        String currentFullName = person.getFullName();
+
+        String currentFirstName = currentFullName.substring(0, currentFullName.indexOf(" "));
+
+        String newFullName = currentFullName.replaceFirst(currentFirstName, firstName);
+
+        person.setFullName(newFullName);
+
+        return responseWrapper(person, 200);
+    }
+
+    @PUT
+    @Path("{personId}/lastName")
+    @Operation(summary = "change the given subject's last name")
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Transactional(rollbackOn = {WebApplicationException.class})
+    public Response changeLastName(@PathParam("personId") Long personId, String lastName)
+            throws WebApplicationException
+    {
+        SubjectMap subjectMap = findSubjectMap(personId);
+
+        keycloak.realm("orppst").users().get(subjectMap.uid).toRepresentation().setLastName(lastName);
+
+        Person person = findObject(Person.class, personId);
+
+        String currentFullName = person.getFullName();
+
+        String currentFirstName = currentFullName.substring(0, currentFullName.indexOf(" "));
+
+        String newFullName = currentFirstName + " " + lastName;
+
+        person.setFullName(newFullName);
+
+        return responseWrapper(person, 200);
+    }
+
+    @PUT
+    @Path("{personId}/email")
+    @Operation(summary = "change the given subject's email address")
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Transactional(rollbackOn = {WebApplicationException.class})
+    public Response changeEmailAddress(@PathParam("personId") Long personId, String emailAddress)
+            throws WebApplicationException
+    {
+        SubjectMap subjectMap = findSubjectMap(personId);
+
+        keycloak.realm("orppst").users().get(subjectMap.uid).toRepresentation().setEmail(emailAddress);
+
+        Person person = findObject(Person.class, personId);
+
+        person.setEMail(emailAddress);
+
+        return responseWrapper(person, 200);
+    }
+
+    @PUT
+    @Path("{personId}/password")
+    @Operation(summary = "reset the given subject's password")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Response resetPassword(@PathParam("personId") Long personId, String newPassword)
+            throws WebApplicationException
+    {
+        // Dev Note: We assume a frontend client has provided a means to check the new password,
+        // i.e., that the user hasn't typo-ed the new password via a confirm method.
+
+        SubjectMap subjectMap = findSubjectMap(personId);
+
+        CredentialRepresentation credentialRepresentation = new CredentialRepresentation();
+        credentialRepresentation.setType("password");
+        credentialRepresentation.setValue(newPassword);
+        credentialRepresentation.setTemporary(false); //just to be explicit
+
+        keycloak.realm("orppst").users().get(subjectMap.uid).resetPassword(credentialRepresentation);
+
+        return emptyResponse204();
+    }
+
+    //convenience functions
+    private SubjectMap findSubjectMap(Long personId) {
+        String queryStr = "select o from SubjectMap o where o.person._id = :id";
+        TypedQuery<SubjectMap> q = em.createQuery(queryStr, SubjectMap.class);
+        return q.setParameter("id", personId).getSingleResult();
+    }
 
 }


### PR DESCRIPTION
I've added the following end points:

Person: change their home institution
Person: change their ORCHID id
SubjectMap: change first name of user
SubjectMap: change last name of user
SubjectMap: change email address (with implementation checking uniqueness of address)
SubjectMap: reset user password

All SubjectMap endpoints protected by '@RolesAllowed' annotation. 