### PR TITLE
replace hardcoded server url with value read from properties file

### DIFF
--- a/src/main/java/org/orph2020/pst/apiimpl/rest/SubjectMapResource.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/SubjectMapResource.java
@@ -45,7 +45,7 @@ public class SubjectMapResource extends ObjectResourceBase {
     @ConfigProperty(name = "keycloak.admin-password")
     String admin_password;
 
-    @ConfigProperty(name = "quarkus.oidc.auth-server-master")
+    @ConfigProperty(name = "auth-server-master")
     String authServerMaster;
 
     @PostConstruct

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -44,8 +44,8 @@ quarkus.jackson.serialization-inclusion=non_empty
 # attach to keycloak via the backend pod network in production.
 %prod.quarkus.oidc.auth-server-url=http://keycloak/aai/realms/orppst
 %dev.quarkus.oidc.auth-server-url=http://localhost:53536/realms/orppst
-%prod.quarkus.oidc.auth-server-master=http://keycloak/aai
-%dev,test.quarkus.oidc.auth-server-master=http://localhost:53536
+%prod.auth-server-master=http://keycloak/aai
+%dev,test.auth-server-master=http://localhost:53536
 quarkus.oidc.client-id=pst-api
 #FIXME this secret should come from a vault (same as for the GUI)
 quarkus.oidc.credentials.secret=eLt4izrWhxRftFTWTIcMbQsYlbyhfZtU


### PR DESCRIPTION
Added property 'quarkus.oidc.auth-server-master' for both 'prod' and 'dev' profiles - hopefully with the correct url value. This property is then used in SubjectMapResource.