### PR TITLE
add validation warning messages re: short justification texts

### DIFF
--- a/src/main/java/org/orph2020/pst/apiimpl/rest/ProposalResource.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/ProposalResource.java
@@ -305,12 +305,20 @@ public class ProposalResource extends ObjectResourceBase {
             int scientificLength = proposal.getScientificJustification().getText().length();
             int technicalLength = proposal.getTechnicalJustification().getText().length();
 
-            if (scientificLength < justificationsLengthCheck) {
+            //reminder: cannot save an empty string in justification text so an "empty" justification has 1 character
+            if (scientificLength < 2) {
+                error.append("No scientific justification text written.<br/>");
+                valid = false;
+            } else if (scientificLength < justificationsLengthCheck) {
                 warn.append("Scientific justification text has ")
                         .append(scientificLength)
                         .append(" characters only. If this is correct please ignore this warning else check your scientific justification.<br/>");
             }
-            if (technicalLength < justificationsLengthCheck) {
+
+            if  (technicalLength < 2) {
+                error.append("No technical justification text written.<br/>");
+                valid = false;
+            } else if (technicalLength < justificationsLengthCheck) {
                 warn.append("Technical justification text has ")
                         .append(technicalLength)
                         .append(" characters only. If this is correct please ignore this warning else check your technical justification.<br/>");


### PR DESCRIPTION
API will now check the character length of the Justification texts against a hardcoded value of 256. If less than this value a warning is emitted to the user to check their Justification. 