### PR TITLE
130 errors messages from bibtex not emitted to client

### DIFF
--- a/src/main/java/org/orph2020/pst/apiimpl/rest/JustificationsResource.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/JustificationsResource.java
@@ -453,12 +453,12 @@ public class JustificationsResource extends ObjectResourceBase {
                 if (line.contains("LaTeX Error")) {
                     // "LaTeX Error"s contain the details on the current line
                     list.add(line);
-                } else if (line.contains("Runaway argument?")) {
-                    list.add(line + " - " + scanner.nextLine() + " - have you forgotten a '}'?");
                 } else if (scanner.hasNextLine()) {
                     // other errors have the details on the next line
                     list.add(line + ": " + scanner.nextLine());
                 }
+            } else if (line.contains("Runaway argument?")) {
+                list.add(line + " - " + scanner.nextLine() + " - have you forgotten a '}'?");
             }
         }
         scanner.close();


### PR DESCRIPTION
Improved the error messaging from the API to the client. Will warn about a missing .bib file, list syntax problems in the .bib file, and has better messaging for Latex errors by using context.

I've tried finding references to specific line numbers when there are Latex errors in either the scientific or technical justification tex files, but as we "input" these into the 'main.tex' file the only line number mentioned is where those input commands occur in 'main.tex'. 