### PR TITLE
Allow reviewers to access enough to review submitted proposals

### DIFF
--- a/src/main/java/org/orph2020/pst/apiimpl/rest/JustificationsResource.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/JustificationsResource.java
@@ -169,7 +169,7 @@ public class JustificationsResource extends ObjectResourceBase {
 
     @POST
     @Path("ReviewPdf")
-    @RolesAllowed({"tac_member", "tac_admin"})
+    @RolesAllowed({"tac_member", "tac_admin", "reviewer"})
     @Operation(summary = "create and download an anonymised summary of the whole proposal in a zip with compiled justifications, for reviewers only")
     @Produces(MediaType.APPLICATION_JSON)
     @Transactional(rollbackOn = {WebApplicationException.class})
@@ -196,7 +196,7 @@ public class JustificationsResource extends ObjectResourceBase {
 
     @POST
     @Path("ReviewZip")
-    @RolesAllowed({"tac_member", "tac_admin"})
+    @RolesAllowed({"tac_member", "tac_admin", "reviewer"})
     @Operation(summary = "create and download an anonymised summary in a zip with compiled justifications, for reviewers only")
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
     @Transactional(rollbackOn = {WebApplicationException.class})

--- a/src/main/java/org/orph2020/pst/apiimpl/rest/ProposalCyclesResource.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/ProposalCyclesResource.java
@@ -146,7 +146,7 @@ public class ProposalCyclesResource extends ObjectResourceBase {
     @GET
     @Path("{cycleCode}")
     @Operation(summary = "get the given proposal cycle")
-    @RolesAllowed({"tac_member", "tac_admin", "obs_administration"})
+    @RolesAllowed({"tac_member", "tac_admin", "obs_administration", "reviewer"})
     public ProposalCycle getProposalCycle(@PathParam("cycleCode") long cycleId) {
         return findObject(ProposalCycle.class,cycleId);
     }

--- a/src/main/java/org/orph2020/pst/apiimpl/rest/ProposalReviewResource.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/ProposalReviewResource.java
@@ -25,7 +25,7 @@ public class ProposalReviewResource extends ObjectResourceBase{
 
     @GET
     @Operation(summary = "get the ObjectIdentifiers of the reviews of the given SubmittedProposal")
-    @RolesAllowed({"tac_admin", "tac_member", "obs_administration"})
+    @RolesAllowed({"tac_admin", "tac_member", "obs_administration", "reviewer"})
     public List<ObjectIdentifier> getReviews(@PathParam("cycleCode") Long cycleCode,
                                              @PathParam("submittedProposalId") Long submittedProposalId,
                                              @RestQuery String reviewerId
@@ -49,7 +49,7 @@ public class ProposalReviewResource extends ObjectResourceBase{
     @GET
     @Path("/{reviewId}")
     @Operation(summary = "get the specific review of the given SubmittedProposal")
-    @RolesAllowed({"tac_admin", "tac_member", "obs_administration"})
+    @RolesAllowed({"tac_admin", "tac_member", "obs_administration", "reviewer"})
     public ProposalReview getReview(@PathParam("cycleCode") Long cycleCode,
                                     @PathParam("submittedProposalId") Long submittedProposalId,
                                     @PathParam("reviewId") Long reviewId)

--- a/src/main/java/org/orph2020/pst/apiimpl/rest/SubmittedProposalResource.java
+++ b/src/main/java/org/orph2020/pst/apiimpl/rest/SubmittedProposalResource.java
@@ -129,7 +129,7 @@ public class SubmittedProposalResource extends ObjectResourceBase{
     @GET
     @Path("/{submittedProposalId}")
     @Operation(summary = "get the SubmittedProposal specified by 'submittedProposalId'")
-    @RolesAllowed({"tac_admin", "tac_member"})
+    @RolesAllowed({"tac_admin", "tac_member", "reviewer"})
     public SubmittedProposal getSubmittedProposal(@PathParam("cycleCode") Long cycleCode,
                                                 @PathParam("submittedProposalId") Long submittedProposalId)
     {
@@ -139,7 +139,7 @@ public class SubmittedProposalResource extends ObjectResourceBase{
 
     @GET
     @Path("/notYetAllocated")
-    @RolesAllowed({"tac_admin", "tac_member"})
+    @RolesAllowed({"tac_admin", "tac_member", "reviewer"})
     @Operation(summary = "get the Submitted Proposal Ids that have yet to be Allocated in the given cycle")
     public List<ObjectIdentifier> getSubmittedNotYetAllocated(@PathParam("cycleCode") Long cycleCode)
         throws WebApplicationException
@@ -205,7 +205,7 @@ public class SubmittedProposalResource extends ObjectResourceBase{
 
     @GET
     @Path("allReviewsLocked")
-    @RolesAllowed({"tac_admin", "tac_member"})
+    @RolesAllowed({"tac_admin", "tac_member", "reviewer"})
     @Operation(summary = "check that the reviews for all submitted proposals have been locked")
     public boolean checkAllReviewsLocked(@PathParam("cycleCode") Long cycleCode)
         throws WebApplicationException


### PR DESCRIPTION
Roles and permissions still need more work, this is outstanding in [issue 92](https://github.com/orppst/pst-api-service/issues/42).

These changes allow reviewers to access the endpoints to review proposals.